### PR TITLE
Enable logging with console.log

### DIFF
--- a/test/root.js
+++ b/test/root.js
@@ -15,6 +15,8 @@ beforeEach(function(done) {
       return done(err);
     }
 
+    jsdom.getVirtualConsole(window).sendTo(console);
+
     Object.keys(window).forEach(key => {
       global[key] = window[key];
     });


### PR DESCRIPTION
Using `console.log` within `index.js` produces no output because it's captured by `jsdom`'s virtual console.  This pull request forwards the `jsdom` virtual console output to the standard console output.  This is especially useful for debugging student-written code.